### PR TITLE
fix: add dollar sign before the git clone command

### DIFF
--- a/docs/create-candy/01-introduction.md
+++ b/docs/create-candy/01-introduction.md
@@ -49,7 +49,7 @@ Creating and controlling a Candy Machine is typically done through command line 
 You can clone this repository anywhere you like, but the recommended practice is:
 
 ```
-git clone --branch v1.0.0 https://github.com/metaplex-foundation/metaplex.git ~/metaplex-foundation/metaplex
+$ git clone --branch v1.0.0 https://github.com/metaplex-foundation/metaplex.git ~/metaplex-foundation/metaplex
 ```
 
 If you use a different location, you'll need to adjust for it in subsequent instructions.


### PR DESCRIPTION
I was browsing the Candy Machine documentation (https://docs.metaplex.com/create-candy/introduction#prerequisites) and I found out that one command was not formatted in the same way as the others. The only thing missing was the dollar sign in front of the git clone command.