### PR TITLE
improve readability of stability link

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -57,7 +57,7 @@ html[data-theme="dark"] .docusaurus-highlight-code-line {
   line-height: 1.5;
 }
 .api_stability a {
-  color: rgb(88, 95, 88);
+  color: black;
   text-decoration: underline;
 }
 .api_stability_0 {


### PR DESCRIPTION
Before 

<img width="751" alt="Screen Shot 2021-12-08 at 1 35 11 PM" src="https://user-images.githubusercontent.com/166834/145288118-2e5ce565-8fd2-4565-b88c-3e35cfacc18f.png">

After 

<img width="769" alt="Screen Shot 2021-12-08 at 1 34 55 PM" src="https://user-images.githubusercontent.com/166834/145288123-17718d45-ede9-4866-8b4e-30a0522503e4.png">
