### PR TITLE
replace invalid example Solana address w/ valid one

### DIFF
--- a/docs/nft-standard.md
+++ b/docs/nft-standard.md
@@ -82,7 +82,7 @@ Here is an example of off-chain JSON metadata.
     "category": "video",
     "creators": [
       {
-        "address": "SOLFLR15asd9d21325bsadythp547912501b",
+        "address": "xEtQ9Fpv62qdc1GYfpNReMasVTe9YW5bHJwfVKqo72u",
         "share": 100
       }
     ]


### PR DESCRIPTION
The Solana address in the example Metadata JSON file does not evaluate to a valid Solana public key: it's too short and uses non-base58 characters. I've replaced it with https://solscan.io/account/xEtQ9Fpv62qdc1GYfpNReMasVTe9YW5bHJwfVKqo72u which is the creator address for the SolFlare Holidays NFT.