### PR TITLE
Update 08-mint-tokens.md

### DIFF
--- a/docs/create-candy/08-mint-tokens.md
+++ b/docs/create-candy/08-mint-tokens.md
@@ -18,10 +18,10 @@ ts-node ~/metaplex-foundation/metaplex/js/packages/cli/src/candy-machine-cli.ts 
 
 ## Mint multiple tokens
 - `--number` number of tokens
-```
-//Forr mainnet
-ts-node ~/metaplex-foundation/metaplex/js/packages/cli/src/candy-machine-cli.ts mint_multiple_tokens -k ~/.config/solana/devnet.json --env mainnet-beta --number 2
-//For devnet
-ts-node ~/metaplex-foundation/metaplex/js/packages/cli/src/candy-machine-cli.ts mint_multiple_tokens -k ~/.config/solana/devnet.json --number 2
+```sh
+# For mainnet
+ts-node ~/metaplex-foundation/metaplex/js/packages/cli/src/candy-machine-cli.ts mint_multiple_tokens -k ~/.config/solana/mainnet-beta.json --env mainnet-beta --number 2
 
+# For devnet
+ts-node ~/metaplex-foundation/metaplex/js/packages/cli/src/candy-machine-cli.ts mint_multiple_tokens -k ~/.config/solana/devnet.json --number 2
 ```


### PR DESCRIPTION
Mainnet launch should not use `devnet.json` used for development.