### PR TITLE
removed -cp from mint and verify

### DIFF
--- a/docs/candy-machine-v2/06-verify-upload.md
+++ b/docs/candy-machine-v2/06-verify-upload.md
@@ -11,7 +11,6 @@ The Candy Machine provides a command to verify if the metadata URI on chain has 
 ts-node ~/metaplex/js/packages/cli/src/candy-machine-v2-cli.ts verify \
     -e devnet \
     -k ~/.config/solana/devnet.json \
-    -cp config.json \
     -c example
 ```
 

--- a/docs/candy-machine-v2/07-mint-tokens.md
+++ b/docs/candy-machine-v2/07-mint-tokens.md
@@ -15,7 +15,6 @@ Minting one token can be done using the command `mint_one_token`:
 ts-node ~/metaplex/js/packages/cli/src/candy-machine-v2-cli.ts mint_one_token \
     -e devnet \
     -k ~/.config/solana/devnet.json \
-    -cp config.json \
     -c example
 ```
 
@@ -43,7 +42,6 @@ You can also mint multiple tokens using the command `mint_multiple_tokens` and s
 ts-node ~/metaplex/js/packages/cli/src/candy-machine-v2-cli.ts mint_multiple_tokens \
     -e devnet \
     -k ~/.config/solana/devnet.json \
-    -cp config.json \
     -c example \
     --number 2
 ```


### PR DESCRIPTION
Form `CMv2`, in the Verify and Mint pages, the `-cp` (config path) option is incorrectly documented as part of the commends.

I have removed them as to avoid confusion for others reading the docs.

Close issue #122 after merge.
