### PR TITLE
[CMv2 Docs] Fix the sidebar label

### DIFF
--- a/docs/candy-machine-v2/09-update.md
+++ b/docs/candy-machine-v2/09-update.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: "7. Update the Candy Machine"
+sidebar_label: "8. Update the Candy Machine"
 ---
 # Update the Candy Machine
 


### PR DESCRIPTION
Two sections on the sidebar have `7.` 
![image](https://user-images.githubusercontent.com/82949194/148402050-26735f5a-2876-4015-8736-df16b0a2f5e6.png)
This PR changes the "Update the Candy Machine" section to `8.`