### PR TITLE
Improvements to v1.1.0 docs

### DIFF
--- a/docs/token-metadata/v1.0.0/_category_.json
+++ b/docs/token-metadata/v1.0.0/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "v1.0.0",
-    "position": 0
+    "position": 1
 }

--- a/docs/token-metadata/v1.1.0/_category_.json
+++ b/docs/token-metadata/v1.1.0/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "v1.1.0",
-    "position": 1
+    "position": 0
 }

--- a/docs/token-metadata/v1.1.0/getting-started.md
+++ b/docs/token-metadata/v1.1.0/getting-started.md
@@ -5,7 +5,10 @@ sidebar_position: 1
 
 # Getting Started with V1.1.0
 
-As a backward-compatible release, you are already using the 1.1.0 version of the specification. It is implemented in the most recent version of the TokenMetadata program. Metaplex is still working on implementing this specification in all our products such as:
+As a backward-compatible release, you are already using the 1.1.0 version of the
+specification. It is implemented in the most recent version of the [Token
+Metadata program][]. Metaplex is still working on implementing this
+specification in all our products such as:
 
 - Candy Machine
 - Auction House
@@ -68,3 +71,6 @@ The cli has great help text that can guide you through.
 Here is the code for the cli.
 
 https://github.com/metaplex-foundation/metaplex/blob/master/js/packages/cli/src/cli-nft.ts
+
+
+[Token Metadata program]: https://github.com/metaplex-foundation/metaplex-program-library/tree/master/token-metadata

--- a/docs/token-metadata/v1.1.0/overview.md
+++ b/docs/token-metadata/v1.1.0/overview.md
@@ -5,41 +5,55 @@ sidebar_position: 0
 
 # Overview
 
-The Metaplex Token Metadata Standard is an evolving standard for general token metadata on the Solana blockchain. This is the newest version of the standard and contains a number of improvements and additions to the standard while maintaining backwards compatibility.
+The Metaplex Token Metadata Standard is an evolving standard for general token metadata on the [Solana][] blockchain. `v1.1.0` is the newest version of the standard and contains a number of improvements and additions while maintaining backwards compatibility with [v1.0.0](/token-metadata/v1.0.0/nft-standard).
 
-### **Summary of Changes from V1.1.0**
+### **Summary of Changes in v1.1.0**
 
-Additions:
+#### New Features
 
-- On-Chain Collections
-- Token Standards
-- Token Uses
+- [On-Chain Collections](/token-metadata/v1.1.0/specification#collections)
+- [Token Standards](/token-metadata/v1.1.0/specification#token-standards)
+- [Token Uses][uses]
 
-Addition of Instructions:
+#### New Instructions
 
-- CreateMetadataAccountV2 -> Same as CreateMetadataAccount, But allows Collections and Use , also sets `TokenStandard`
-- UpdateMetadataAccountV2 -> Same as UpdateMetadataAccount, But allows Collections and Use , also sets `TokenStandard`
-- CreateMasterEditionV3 -> Same as CreateMasterEdition, but sets the `TokenStandard` on the NFT
-- VerifyCollection -> Allows a collection `verified` flag to become true on an NFT to represent a Certified Collection. Essentially this Officially Adds to a Collection.
-- UnVerifyCollection -> Allows a collection `verified` flag to become false on an NFT to represent a Certified Collection, Essentially this Officially Removes from a Collection.
-- Utilize -> Allows a limited "Use" semantic. Can be used to represent a ticket, pass, game item or physical item redemption.
-- ApproveUseAuthority -> Approve an authority to call `Utilize`
-- RevokeUseAuthority -> Remove a granted authority to call `Utilize`
-- ApproveCollectionAuthority -> Approve an authority to call `VerifyCollection`
-- RevokeCollectionAuthority -> Remove a granted authority to call `VerifyCollection`
+- `CreateMetadataAccountV2`
+  - Same as `CreateMetadataAccount`, but supports `Collections`, `Use` and `TokenStandard`
+- `UpdateMetadataAccountV2`
+  - Same as `UpdateMetadataAccount`, but supports `Collections`, `Use` and `TokenStandard`
+- `CreateMasterEditionV3`
+  - Same as `CreateMasterEdition`, but supports `TokenStandard`
+- `VerifyCollection`
+  - Allows a collection `verified` flag to become `true` on an NFT to represent a Certified Collection. Essentially this officially adds to a Collection.
+- `UnVerifyCollection`
+  - Allows a collection `verified` flag to become `false` on an NFT to represent a Certified Collection. Essentially this officially removes from a Collection.
+- `Utilize`
+  - Allows a ["limited use" semantic][uses]. Can be used to represent a ticket, pass, game item or physical item redemption.
+- `ApproveUseAuthority`
+  - Approves an authority to call `Utilize`
+- `RevokeUseAuthority`
+  - Removes a granted authority to call `Utilize`
+- `ApproveCollectionAuthority`
+  - Approves an authority to call `VerifyCollection`
+- `RevokeCollectionAuthority`
+  - Removes a granted authority to call `VerifyCollection`
 
-Deprecation:
+#### Deprecations
 
-- Deprecation(not removal) of "collection" and "creators" field in the token metadata JSON
-- Depreciation of V1 Instructions: These will now show a deprecation warning but will work fine
-- CreateMetadataAccount
-- UpdateMetadataAccount
-- CreateMasterEdition -> This may be confusing that there is no `V2` but for historical reasons this instruction is `V2`. The V1 had its name changed in a backward incompatible way see `DeprecatedCreateMasterEdition`
+- Deprecation (not removal) of "collection" and "creators" field in the token metadata JSON
+- The following v1 instructions now show a deprecation warning when executed
+  - `CreateMetadataAccount` - _please use `CreateMetadataAccountV2` instead_
+  - `UpdateMetadataAccount` - _please use `UpdateMetadataAccountV2` instead_
+  - `CreateMasterEdition` - _please use `CreateMasterEditionV3` instead_
+    - It may be confusing that there is no `V2` but for historical reasons this instruction actually was `V2`. The V1 had its name changed in a backward incompatible way.
 
-Removals:
+#### Removals
 
-- Removal Of Deprecated Instructions
-- DeprecatedCreateMasterEdition
-- DeprecatedCreateReservationList
-- DeprecatedMintPrintingTokensViaToken
-- DeprecatedMintPrintingTokens
+Removal of previously deprecated instructions
+  - `DeprecatedCreateMasterEdition`
+  - `DeprecatedCreateReservationList`
+  - `DeprecatedMintPrintingTokensViaToken`
+  - `DeprecatedMintPrintingTokens`
+
+[Solana]: https://solana.com
+[uses]: /token-metadata/v1.1.0/specification#token-use-settings

--- a/docs/token-metadata/v1.1.0/specification.md
+++ b/docs/token-metadata/v1.1.0/specification.md
@@ -7,15 +7,20 @@ sidebar_position: 2
 
 ## **Collections**
 
-On-chain collections are added to this version of the standard replacing the collection field defined in the external JSON metadata and the various community ad-hoc heuristics for determining a collection, with an objective and easy-to-use on-chain implementation.
+Introduced in v1.1.0 of the token metadata standard, _on-chain collections_
+replace the `collection` field previously defined in external JSON metadata.
+Gone are the ad-hoc community heuristics for determining a collection,
+superceded with an objective, easy-to-use on-chain implementation.
 
 ### **On-Chain Representation of a Collection**
 
-A collection is an NFT and has the same data layout on chain that a regular NFT has. And NFTs are linked to the collection in a belongs_to style where the NFT has a reference back to the collection:
+:::info
+A `collection` is an NFT. It has the same data layout on-chain as any other NFT.
+:::
 
-This is done by the addition of a new field in the Token Metadata (`mpl-token-metadata`) `Metadata` struct. The `collection` field maps to the Mint Address of the collection NFT and is represented as the Rust type `Option<Collection>` where a value of `None` will be interpreted to mean that a NFT does not belong to any collection. The Collection struct has the fields `verified` denoting whether or not the collection is verified and `key` which points to mint account of the collection.
-
-#### Code
+An NFT is linked to a collection in a belongs_to style where the NFT has a
+reference back to the collection. This is implemented through the addition of
+a new `collection` field in the [Token Metadata][] struct.
 
 ```rust
 pub struct Metadata {
@@ -32,19 +37,23 @@ pub struct Metadata {
     /// Since we cannot easily change Metadata, we add the new DataV2 fields here at the end.
     /// Collection
     pub collection: Option<Collection>,
-    . . .
+    ...
 }
-```
 
-```Rust
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug, Clone)]
 pub struct Collection {
-    pub verified: bool,
-    pub key: Pubkey,
+  pub verified: bool, // Whether or not the collection is verified
+  pub key: Pubkey,    // The SPL token mint account of the collection NFT
 }
 ```
 
-#### Table Format
+The metadata `collection` field maps to the Mint Address of the collection NFT and is
+represented as the Rust type `Option<Collection>` where a value of `None` is
+interpreted to mean the NFT does not belong to any collection. The `Collection`
+struct has the fields `verified` denoting whether or not the collection is
+verified (see below) and `key` which points to the `mint` account of the collection NFT.
+
+#### Collection struct fields
 
 | Field    | Type   | Description                                |
 | -------- | ------ | ------------------------------------------ |
@@ -59,16 +68,19 @@ Explorers, Wallets and Marketplaces, MUST CHECK IF `verified` is true. Verified 
 This is the exact same pattern as the `Creators` field where `verified` must be true in order to validate the NFT.
 :::
 
-This implementationhas the following advantages:
+This implementation has the following advantages:
 
-- Easy to identify which collection any given NFT belongs to without making any additional on-chain calls
+- Easy to identify which collection any given NFT belongs to without making additional on-chain calls
 - Possible to find all NFTs that belong to a given collection by making a `getProgramAccounts` call
 - Uses existing padding at the end of `Metadata` so adds no on-chain rent storage costs
 
 ### Delegate Collection Authority Record
 
-Update Authorities on a Collection NFT can delegate the authority to call the `verify_collection` instruction. This allows you to delegate the ability to add nfts to your collection to many parties. You can do this by calling the
-`approve_collection_authority` instruction, to revoke you can call the `revoke_collection_authority` instruction.
+Update Authorities on a Collection NFT can delegate the authority to call the
+`verify_collection` instruction. This allows you to delegate the ability to add
+NFTs to your collection to many parties. You can do this by calling the
+`approve_collection_authority` instruction. To revoke you can call the
+`revoke_collection_authority` instruction.
 
 ## **Token Standards**
 
@@ -81,11 +93,10 @@ This solves a current pain-point for third parties such as wallets which are app
 Token Standards are defined by a Rust enum:
 
 ```rust
-
 pub enum TokenStandard {
-    NonFungible, // This is a master edition
-    FungibleAsset, // A token with metadata that can also have attrributes, sometimes called Semi Fungible
-    Fungible, // A token with simple metadata
+    NonFungible,   // This is a master edition
+    FungibleAsset, // A token with metadata that can also have attributes, sometimes called Semi Fungible
+    Fungible,      // A token with simple metadata
     NonFungibleEdition, // This is a limited edition
 }
 ```
@@ -305,16 +316,26 @@ pub struct Metadata {
 
 The following instructions have been added to support the new token specification:
 
-- CreateMetadataAccountV2 -> Same as CreateMetadataAccount, But allows Collections and Use , also sets `TokenStandard`
-- UpdateMetadataAccountV2 -> Same as UpdateMetadataAccount, But allows Collections and Use , also sets `TokenStandard`
-- CreateMasterEditionV3 -> Same as CreateMasterEdition, but sets the `TokenStandard` on the NFT
-- VerifyCollection -> Allows a collection `verified` flag to become true on an NFT to represent a Certified Collection. Essentially this Officially Adds to a Collection.
-- UnVerifyCollection -> Allows a collection `verified` flag to become false on an NFT to represent a Certified Collection, Essentially this Officially Removes from a Collection.
-- Utilize -> Allows a limited "Use" semantic. Can be used to represent a ticket, pass, game item or physical item redemption.
-- ApproveUseAuthority -> Approve an authority to call `Utilize`
-- RevokeUseAuthority -> Remove a granted authority to call `Utilize`
-- ApproveCollectionAuthority -> Approve an authority to call `VerifyCollection`
-- RevokeCollectionAuthority -> Remove a granted authority to call `VerifyCollection`
+- `CreateMetadataAccountV2`
+  - Same as `CreateMetadataAccount`, but supports `Collections`, `Use` and `TokenStandard`
+- `UpdateMetadataAccountV2`
+  - Same as `UpdateMetadataAccount`, but supports `Collections`, `Use` and `TokenStandard`
+- `CreateMasterEditionV3`
+  - Same as `CreateMasterEdition`, but supports `TokenStandard`
+- `VerifyCollection`
+  - Allows a collection `verified` flag to become `true` on an NFT to represent a Certified Collection. Essentially this officially adds to a Collection.
+- `UnVerifyCollection`
+  - Allows a collection `verified` flag to become `false` on an NFT to represent a Certified Collection. Essentially this officially removes from a Collection.
+- `Utilize`
+  - Allows a ["limited use" semantic][uses]. Can be used to represent a ticket, pass, game item or physical item redemption.
+- `ApproveUseAuthority`
+  - Approves an authority to call `Utilize`
+- `RevokeUseAuthority`
+  - Removes a granted authority to call `Utilize`
+- `ApproveCollectionAuthority`
+  - Approves an authority to call `VerifyCollection`
+- `RevokeCollectionAuthority`
+  - Removes a granted authority to call `VerifyCollection`
 
 The first two perform the same role as their v1 versions but with support for the extra fields. `UpdateMetadataAccountV2` allows existing NFTs to be upgraded to support these new standards by adding the extra fields to their token metadata account.
 
@@ -322,18 +343,21 @@ The first two perform the same role as their v1 versions but with support for th
 
 The following items and instructions have been deprecated in v1.1.0:
 
-- Depreciation of V1 Instructions: These will now show a deprecation warning but will work fine
-- CreateMetadataAccount
-- UpdateMetadataAccount
-- JSON Deprecation:
-  - creators field
-  - collection field
+- Deprecation (not removal) of "collection" and "creators" field in the token metadata JSON
+- The following v1 instructions now show a deprecation warning when executed
+  - `CreateMetadataAccount` - _please use `CreateMetadataAccountV2` instead_
+  - `UpdateMetadataAccount` - _please use `UpdateMetadataAccountV2` instead_
+  - `CreateMasterEdition` - _please use `CreateMasterEditionV3` instead_
+    - It may be confusing that there is no `V2` but for historical reasons this instruction actually was `V2`. The V1 had its name changed in a backward incompatible way.
 
 ### Removed Items
 
-Removal Of Deprecated Instructions
+Removal of previously deprecated instructions
 
-- DeprecatedCreateMasterEdition
-- DeprecatedCreateReservationList
-- DeprecatedMintPrintingTokensViaToken
-- DeprecatedMintPrintingTokens
+- `DeprecatedCreateMasterEdition`
+- `DeprecatedCreateReservationList`
+- `DeprecatedMintPrintingTokensViaToken`
+- `DeprecatedMintPrintingTokens`
+
+
+[Token Metadata]: https://github.com/metaplex-foundation/metaplex-program-library/tree/master/token-metadata/program

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -43,21 +43,21 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
       algolia: {
         // If Algolia did not provide you any appId, use 'BH4D9OD16A'
         appId: 'ONUK0F738E',
-  
+
         // Public API key: it is safe to commit it
         apiKey: '09fae30a579686b02e9effdcd429b2d1',
-  
+
         indexName: 'metaplex',
-  
+
         // Optional: see doc section below
         contextualSearch: true,
-  
+
         // Optional: Specify domains where the navigation should occur through window.location instead on history.push. Useful when our Algolia config crawls multiple documentation sites and we want to navigate with window.location.href to them.
         // externalUrlRegex: 'external\\.com|domain\\.com',
-  
+
         // Optional: Algolia search parameters
         searchParameters: {},
-  
+
         //... other Algolia params
       },
       navbar: {
@@ -106,6 +106,7 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
       prism: {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
+        additionalLanguages: ['rust'],
       },
     }),
 });


### PR DESCRIPTION
- adds global rust syntax highlighting
- sidebar: move v1.1.0 above v1.0.0 to emphasis the latest version
- uses more markdown headers to allow deep links
- uses deep links and adds links to MPL
- formats technical terms with backticks
- spelling corrections

### new
<img width="1064" alt="Screen Shot 2022-01-19 at 8 22 10 AM" src="https://user-images.githubusercontent.com/166834/150172161-20745a52-63db-4c2b-95be-460b380578d5.png">


### old
<img width="1056" alt="Screen Shot 2022-01-19 at 8 22 00 AM" src="https://user-images.githubusercontent.com/166834/150172299-4ad5c4d6-adca-4445-957d-051d462c54f3.png">
