### PR TITLE
add config options for nft.storage uploads

### DIFF
--- a/docs/candy-machine-v2/02-configuration.md
+++ b/docs/candy-machine-v2/02-configuration.md
@@ -40,9 +40,11 @@ The table below provides an overview of the settings available:
 |                       |                   | “arweave-bundle”       | Uploads to arweave and payment are made in AR (only works in mainnet and requires an Arweave wallet) |
 |                       |                   | “arweave”              | Uploads to arweave via Metaplex Google Cloud function (works on devnet and mainnet, recommended option for devnet) |
 |                       |                   | “ipfs”                 | Uploads to IPFS (must specify either Infura Project ID or Secret Key) |
+|                       |                   | “nft-storage”                 | Uploads to [NFT.Storage](https://nft.storage) (works on all networks, must provide `nftStorageKey`) |
 |                       |                   | “aws”                  | Uploads to AWS (must specify AWS Bucket name) |
 | ipfsInfuraProjectId   |                   | String                 | Infura Project ID |
 | ipfsInfuraSecret      |                   | String                 | Infure Project Secret |
+| nftStorageKey         |                   | String                 | NFT.Storage API Key |
 | arweaveJwk            |                   | String                 | Arweave JWK wallet file |
 | awsS3Bucket           |                   | String                 | AWS bucket name |
 | noRetainAuthority     |                   | boolean                | Indicates whether the candy machine authority has the update authority for each mint or not |


### PR DESCRIPTION
Hi, this updates the configuration guide for CMv2 to include the nft.storage options added in https://github.com/metaplex-foundation/metaplex/pull/1512

I'm happy to write a more detailed example if that's of interest :)