### PR TITLE
update docs for using nft.storage

### DIFF
--- a/docs/candy-machine-v2/02-configuration.md
+++ b/docs/candy-machine-v2/02-configuration.md
@@ -40,11 +40,11 @@ The table below provides an overview of the settings available:
 |                       |                   | “arweave-bundle”       | Uploads to arweave and payment are made in AR (only works in mainnet and requires an Arweave wallet) |
 |                       |                   | “arweave”              | Uploads to arweave via Metaplex Google Cloud function (works on devnet and mainnet, recommended option for devnet) |
 |                       |                   | “ipfs”                 | Uploads to IPFS (must specify either Infura Project ID or Secret Key) |
-|                       |                   | “nft-storage”                 | Uploads to [NFT.Storage](https://nft.storage) (works on all networks, must provide `nftStorageKey`) |
+|                       |                   | “nft-storage”                 | Uploads to [NFT.Storage](https://nft.storage) (no payment required, works on all networks) |
 |                       |                   | “aws”                  | Uploads to AWS (must specify AWS Bucket name) |
 | ipfsInfuraProjectId   |                   | String                 | Infura Project ID |
 | ipfsInfuraSecret      |                   | String                 | Infure Project Secret |
-| nftStorageKey         |                   | String                 | NFT.Storage API Key |
+| nftStorageKey         |                   | String                 | NFT.Storage API Key (optional) |
 | arweaveJwk            |                   | String                 | Arweave JWK wallet file |
 | awsS3Bucket           |                   | String                 | AWS bucket name |
 | noRetainAuthority     |                   | boolean                | Indicates whether the candy machine authority has the update authority for each mint or not |
@@ -73,6 +73,7 @@ A minimal Candy Machine config settings looks like this:
     "storage": "arweave-sol",
     "ipfsInfuraProjectId": null,
     "ipfsInfuraSecret": null,
+    "nftStorageKey": null,
     "awsS3Bucket": null,
     "noRetainAuthority": false,
     "noMutable": false

--- a/docs/overviews/storage_overview.md
+++ b/docs/overviews/storage_overview.md
@@ -51,6 +51,21 @@ import ArweaveCostCalc from '../../src/arweave-cost-calc.jsx'
 
 <ArweaveCostCalc />
 
+### NFT.Storage
+
+[NFT.Storage](https://nft.storage) is a free service that provides long-term NFT data storage on the decentralized [Filecoin](https://filecoin.io) network with fast retrieval through [IPFS][IPFS].
+
+NFT.Storage currently supports files up to 31 Gib and does not charge for storage.
+
+#### Using NFT.Storage
+
+NFT.Storage is currently only supported within the CandyMachine `upload` command. Please see the [configuration guide][cmv2 config guide] for details about the configuration settings to use.
+
+Note that when using the `nft-storage` configuration setting, you can optionally also set an `nftStorageKey` to an NFT.Storage API token. Setting an `nftStorageKey` will allow you to view uploads in your NFT.Storage account's file listing. 
+
+If you do not provide an API key, the Solana keypair used for the `upload` command will be used to sign an upload request message, which is used to authenticate the upload with NFT.Storage. This allows you to upload without an NFT.Storage account, but you will not be able to manage the upload using the NFT.Storage service afterwards.
+
+For more information about using NFT.Storage with CandyMachine, see the [NFT.Storage documentation on Metaplex][nft.storage metaplex doc]
 
 ### IPFS
 
@@ -106,3 +121,5 @@ page](https://github.com/metaplex/docs/edit/main/docs/overview/storage_overview.
 [winstons]: https://docs.arweave.org/developers/server/http-api#ar-and-winston
 [S3]: https://aws.amazon.com/s3/
 [arweave path manifest]: https://github.com/ArweaveTeam/arweave/wiki/Path-Manifests
+[cmv2 config guide]: ../candy-machine-v2/02-configuration.md
+[nft.storage metaplex doc]: https://nft.storage/docs/how-to/mint-solana


### PR DESCRIPTION
This updates the Candy Machine v2 configuration doc to indicate that the `nftStorageKey` is now optional, as of https://github.com/metaplex-foundation/metaplex/pull/1757

I also added a section about NFT.Storage to the Storage Overview doc, with a link to [our new Solana / Metaplex page on the NFT.Storage docs site](https://nft.storage/docs/how-to/mint-solana).

Let me know if there's anything else that makes sense to update!

@stegaBOB if you have a minute to review, that would be awesome :)