### PR TITLE
Update 04-creating-candy-machine.md

### DIFF
--- a/docs/candy-machine-v2/04-creating-candy-machine.md
+++ b/docs/candy-machine-v2/04-creating-candy-machine.md
@@ -27,6 +27,11 @@ ts-node ~/metaplex/js/packages/cli/src/candy-machine-v2-cli.ts upload \
     -c example \
     ./assets
 ```
+:::caution
+
+The `-e` flag specifies the environment and is comprised of the following options: `mainnet-beta`, `testnet` & `devnet`. Please make sure you do not have any typos before executing the above command as all your funds may be irretrievably drained if you ran it the command with a typo in the `-e` flag.
+
+:::
 
 :::warning
 


### PR DESCRIPTION
Adding the options for environments plain as day so that others don't make the mistake that I just did of using `mainnet` as the env option which resulted in my "rent" being irretrievable.