### PR TITLE
metadata account address instead of cache file

### DIFF
--- a/docs/candy-machine-v2/10-sign-nfts.md
+++ b/docs/candy-machine-v2/10-sign-nfts.md
@@ -13,7 +13,7 @@ It is also suggested to use a custom RPC for this step because it is a heavy com
 ts-node ~/metaplex/js/packages/cli/src/candy-machine-v2-cli.ts sign \
     -e devnet \
     -k ~/.config/solana/devnet.json \
-    -c example
+    -m <metadata Address>
 ```
 
 ### Sign All


### PR DESCRIPTION
Currently the documentation is incorrect. signing of a single token does not work through the cache file with -c but -m and the metadata address