### PR TITLE
Clarify Gumdrop docs

### DIFF
--- a/docs/airdrops/create-gumdrop.md
+++ b/docs/airdrops/create-gumdrop.md
@@ -16,7 +16,7 @@ Gumdrop is a new feature from the metaplex community. It is currently in BETA so
 
 The Gumdrop program leverages the Solana blockchain and merkle trees to
 facilitate airdrops to a large number of whitelisted users at a low cost to
-creators.
+creators. Users have to redeem the airdrop, it will not automatically appear in their wallet.
 
 ## Motivation
 

--- a/docs/airdrops/create-gumdrop.md
+++ b/docs/airdrops/create-gumdrop.md
@@ -221,10 +221,17 @@ The distribution method handles are as follows:
 | Email    | local-part@domain | john.smith@example.com |
 | SMS      | E.164             | +18005550100           |
 | Discord  | User ID           | 898959704573759608     |
+| Wallets  | wallet public key | 8mTVkib7TwUSsZRTHDQy9EQbw7ZR7xLrvKeyPgkFPgZB |
 
 At the moment, Discord handles are the hardest to programmatically create. One
 option is to query for members in a Discord Guild and filter for the relevant
 users by display-name there.
+
+The distribution list has to be referenced in the create command like this:
+```
+$ ts-node src/gumdrop-cli.ts create \
+--distribution-list <PATH TO WHITELIST JSON>
+```
 
 NB: The frontends do some verification that the Gumdrop being created is
 sufficient to satisfy all the recipients specified. However, these checks are
@@ -242,7 +249,7 @@ The command to close it is:
 
 ```
 ts-node gumdrop-cli.ts close \
-  --base <keypair that was created on gumdrop create> \
+  --base <id.json keypair that was created on gumdrop create> \
   --keypair <your initial keypair> \
   --claim-integration <creation --claim-integration> \
   --<corresponding claim integration flag>


### PR DESCRIPTION
Gumdrop is hard to grasp for some users. Therefore added one sentence that the airdrop has to be **claimed**.

Also --distribution-list was completely missing although it is always a required parameter.