### PR TITLE
add reference to sugar validate command

### DIFF
--- a/docs/02-tools/03-sugar/01-preparing-assets.md
+++ b/docs/02-tools/03-sugar/01-preparing-assets.md
@@ -12,6 +12,8 @@ this guide we will cover the creation of a simple collection to illustrate the m
 Candy Machine distribution. You should familiarize yourself with
 the [Token Metadata Standard](/programs/token-metadata/token-standard).
 
+You can validate that your assets are created properly through the `sugar validate` command that is further described in the [Sugar Commands](tools/sugar/commands#2-validate) section.
+
 ## Example NFT Collection
 
 A 10-item collection will have 20 regular files in total plus 2 additional collection files:


### PR DESCRIPTION
In this [Discord discussion](https://discord.com/channels/848060988636921856/848060988636921859/1002206635197992961) it got apparent that the `sugar validate` command currently is not mentioned in the preparing your assets section.

From my point of view it should at least be mentioned. 