### PR TITLE
fix:(docs) missing link

### DIFF
--- a/docs/02-sdks/02-js/index.md
+++ b/docs/02-sdks/02-js/index.md
@@ -15,6 +15,8 @@ In the meantime, the README page on the [JS SDK GitHub][github] is a great place
 
 🔗 **Helpful links:**
 
-- [GitHub Repository](https://github.com/metaplex-foundation/js)
+- [GitHub Repository][github]
 - [Examples](https://github.com/metaplex-foundation/js-examples)
 - [NPM Package](https://www.npmjs.com/package/@metaplex-foundation/js)
+
+[github]: https://github.com/metaplex-foundation/js


### PR DESCRIPTION
Missing link in docs.

Currently rendering as:
<img width="740" alt="Screenshot 2022-08-12 at 14 24 06" src="https://user-images.githubusercontent.com/14809642/184374685-3b14ce76-eb34-4882-9972-0b4a94f1fbf8.png">

