### PR TITLE
Broken image link in Token metadata instructions

### DIFF
--- a/docs/01-programs/01-token-metadata/03-instructions.md
+++ b/docs/01-programs/01-token-metadata/03-instructions.md
@@ -299,8 +299,7 @@ This instruction allows the update authority of a collection parent NFT to set t
 
 <ProgramInstruction idl={idl} instruction="SetTokenStandard">
 
-![](/assets/programs/token-metadata/
-Token-Metadata-Instruction-Set-Token-Standard.png)
+![](/assets/programs/token-metadata/Token-Metadata-Instruction-Set-Token-Standard.png)
 
 
 This instruction allows an update authority to pass in a metadata account with an optional edition account and then it determines what the correct TokenStandard type is and writes it to the metadata. See [Token Standard](./token-standard) for more information.


### PR DESCRIPTION
Image link for `Set token standard` instruction was broken in `programs > token-metadata > instructions`