### PR TITLE
fix: add launch command to commands reference

### DIFF
--- a/docs/03-developer-tools/00-sugar/06-commands.md
+++ b/docs/03-developer-tools/00-sugar/06-commands.md
@@ -85,6 +85,21 @@ sugar hash --compare 44oZ3goi9ivakeUnbjWbWJpvdgcWCrsi
 sugar hash --compare 44oZ3goi9ivakeUnbjWbWJpvdgcWCrsi --cache my_custom_cache.json
 ```
 
+## launch
+
+The `launch` command is a convenience command that runs four other commands consecutively: 
+* create-config
+* validate
+* upload
+* deploy
+* verify
+
+These five commands allow you to start from a project folder with an assets subfolder in it and go through the entire process of setting up and creating a candy machine, so it's meant as a quickstart command if you don't want to run the steps individually.
+
+```bash
+sugar launch
+```
+
 
 ## mint
 


### PR DESCRIPTION
The `launch` command was missing from the commands reference. This PR adds it. 