### PR TITLE
Sugar guard for token payment is not tokenGate

### DIFF
--- a/docs/03-developer-tools/00-sugar/03-guides/04-sugar-for-cmv3.md
+++ b/docs/03-developer-tools/00-sugar/03-guides/04-sugar-for-cmv3.md
@@ -329,7 +329,7 @@ The Token Gate guard restricts the mint to holders of a specified SPL Token. The
 The Token Payment guard restricts the mint to holders of a specified SPL Token, transferring the required amount to the `destination_ata` address. The amount determines how many tokens are required.
 
 ```json
-"tokenGate" : {
+"tokenPayment" : {
     "amount": number,
     "mint": "<PUBKEY>",
     "destinationAta": "<PUBKEY>"


### PR DESCRIPTION
Looks like a copy paste error. The guard to require token payment is called tokenPayment, not tokenGuard