### PR TITLE
Add Another RPC Provider - GetBlock to the list

### DIFF
--- a/docs/05-resources/00-rpc-providers.md
+++ b/docs/05-resources/00-rpc-providers.md
@@ -39,6 +39,7 @@ The following section includes multiple RPC providers.
 - [Blockdaemon](https://blockdaemon.com/marketplace/solana/)
 - [Figment](https://figment.io/datahub/solana/)
 - [GenesysGo](https://genesysgo.com/)
+- [GetBlock](https://getblock.io/)
 - [QuickNode](https://quicknode.com/)
 - [RunNode](https://runnode.com/)
 - [Syndica](https://syndica.io/)
@@ -108,6 +109,21 @@ After going through the documentation, you can reserve an account in their [port
 | -------- | -------- | -------- | -------- |
 | Requests/sec     | 1     | 100 + 100 extra  | 200 + 200 extra |
 | Archival Node    | -     | -     | - |
+
+### GetBlock
+
+[GetBlock](https://getblock.io/) is the blockchain RPC provider that employs a ‘pay per use’ model: its requests have no ‘expiration date’ so that users only pay for the resources they actually use. It supports more than 50 multiple blockchains. GetBlock guarantees the highest rate limit in free tariff, 60 RPS.
+
+After setting up an account and proceed to choose a plan.
+
+![](https://imgur.com/iqO3rE7") 
+
+| RPC Info | Free | Shared |  Custom |
+| -------- | -------- | -------- | -------- |
+| Requests/month     | 40 000    |  from 5 million to Unlimited | Unlimited |
+| Archival Node    | No   | No  | Yes|
+
+GetBlock users can set up an account using nothing but a cryptocurrency wallet.
 
 ### QuickNode
 

--- a/docs/05-resources/00-rpc-providers.md
+++ b/docs/05-resources/00-rpc-providers.md
@@ -116,7 +116,7 @@ After going through the documentation, you can reserve an account in their [port
 
 After setting up an account and proceed to choose a plan.
 
-![](https://imgur.com/iqO3rE7") 
+![](https://imgur.com/iqO3rE7) 
 
 | RPC Info | Free | Shared |  Custom |
 | -------- | -------- | -------- | -------- |


### PR DESCRIPTION
GetBlock is a competitive RPS provider that can be compared to big whales in this sphere like QuickNode and Alchemy https://getblock.io/blog/best-blockchain-prc-providers-for-2023-researching-cost-efficiency/ So it definitely should be added