### PR TITLE
add link to burn guide

### DIFF
--- a/docs/04-guides/07-archived/01-burn-token.md
+++ b/docs/04-guides/07-archived/01-burn-token.md
@@ -5,7 +5,7 @@ sidebar_label: "Burn Token"
 :::warning
 There is a full burn instruction now which allows to fully burn Metaplex Tokens. If you use the guide below not all Accounts will be closed and you will not get back all rent SOL!
 
-A new Guide will be added soon.
+You can find the new guide [here](../burn-nfts).
 :::
 
 # Burn Token


### PR DESCRIPTION
The archived burn guide was just referencing a new guide that will be created "soon".
This adds a link to the guide instead