### PR TITLE
Add info for CM v3

### DIFF
--- a/docs/03-developer-tools/00-sugar/02-tutorials/00-my-first-candy-machine.md
+++ b/docs/03-developer-tools/00-sugar/02-tutorials/00-my-first-candy-machine.md
@@ -1,7 +1,7 @@
 # My First Candy Machine
 
 :::warning
-This guide is for CM v2. You might want to follow the [more up to date guide](/programs/candy-machine/how-to-guides/my-first-candy-machine-part1) for CM v3.
+This guide is for Candy Machine v2. You might want to follow the [more up to date guide](/programs/candy-machine/how-to-guides/my-first-candy-machine-part1) for Candy Machine v3.
 :::
 
 The goal of this tutorial is to take you from zero to one: you will learn to install Sugar and use its basic commands to configure and deploy a candy machine to Solana's devnet. It will provide you with a foothold on the basics and enough knowledge that you can then use the rest of the developer resources to learn the more advanced details for using Sugar.

--- a/docs/03-developer-tools/00-sugar/02-tutorials/00-my-first-candy-machine.md
+++ b/docs/03-developer-tools/00-sugar/02-tutorials/00-my-first-candy-machine.md
@@ -1,5 +1,9 @@
 # My First Candy Machine
 
+:::warning
+This guide is for CM v2. You might want to follow the [more up to date guide](/programs/candy-machine/how-to-guides/my-first-candy-machine-part1) for CM v3.
+:::
+
 The goal of this tutorial is to take you from zero to one: you will learn to install Sugar and use its basic commands to configure and deploy a candy machine to Solana's devnet. It will provide you with a foothold on the basics and enough knowledge that you can then use the rest of the developer resources to learn the more advanced details for using Sugar.
 
 ## Prerequisite Knowledge

--- a/docs/04-guides/00-candy-machine-ui.md
+++ b/docs/04-guides/00-candy-machine-ui.md
@@ -5,11 +5,12 @@ sidebar_label: "How to set up a Minting UI"
 # A Front End Minting Experience
 
 :::info
+This guide is for CM v2. If you create a CM v3 follow [the v3 guide](/programs/candy-machine/how-to-guides/my-first-candy-machine-part2) instead!
+:::
 
 This guide assumes you have already uploaded and deployed your Candy Machine. 
 If you haven't yet done this, check out [Sugar CLI](/developer-tools/sugar/) to get started!
 
-:::
 
 While the Candy Machine is ready to mint after being deployed, in most cases you will want to provide a front end experience to allow your
 community the chance to mint, too.

--- a/docs/04-guides/00-candy-machine-ui.md
+++ b/docs/04-guides/00-candy-machine-ui.md
@@ -4,8 +4,8 @@ sidebar_label: "How to set up a Minting UI"
 
 # A Front End Minting Experience
 
-:::info
-This guide is for CM v2. If you create a CM v3 follow [the v3 guide](/programs/candy-machine/how-to-guides/my-first-candy-machine-part2) instead!
+:::warning
+This guide is for Candy Machine v2. If you create a Candy Machine v3 follow [the v3 guide](/programs/candy-machine/how-to-guides/my-first-candy-machine-part2) instead!
 :::
 
 This guide assumes you have already uploaded and deployed your Candy Machine. 


### PR DESCRIPTION
Currently many pages reference CM v2 without mentioning it visible it enough.

This creates confusion for users. The PR adds two warnings for it.

A proper rework of the sugar section is still required