### PR TITLE
fix: use guards object for minting

### DIFF
--- a/docs/01-programs/02-candy-machine/08-minting.md
+++ b/docs/01-programs/02-candy-machine/08-minting.md
@@ -123,7 +123,7 @@ const { candyMachine } = await metaplex.candyMachines().create({
 const { nft } = await metaplex.candyMachines().mint({
   candyMachine,
   collectionUpdateAuthority,
-  settings: {
+  guards: {
     thirdPartySigner: { signer: thirdPartySigner },
   },
 });
@@ -213,7 +213,7 @@ const { nft } = await metaplex.candyMachines().mint({
   candyMachine,
   collectionUpdateAuthority,
   group: "nft",
-  settings: {
+  guards: {
     thirdPartySigner: { signer: thirdPartySigner },
     nftPayment: { mint: nftFromRequiredCollection.address },
   },

--- a/docs/01-programs/02-candy-machine/09-available-guards/07-gatekeeper.md
+++ b/docs/01-programs/02-candy-machine/09-available-guards/07-gatekeeper.md
@@ -76,7 +76,7 @@ In the vast majority of cases, we should not need to provide any Mint Settings t
 ```tsx
 const { nft } = await metaplex.candyMachines().mint({
   // ...
-  settings: {
+  guards: {
     // No mint settings required...
   }
 });
@@ -97,7 +97,7 @@ const gatewayToken = Pda.find(gatewayProgram.address, [
 
 const { nft } = await metaplex.candyMachines().mint({
   // ...
-  settings: {
+  guards: {
     gatekeeper: {
       tokenAccount: gatewayToken,
     },

--- a/docs/01-programs/02-candy-machine/09-available-guards/09-nft-burn.md
+++ b/docs/01-programs/02-candy-machine/09-available-guards/09-nft-burn.md
@@ -59,7 +59,7 @@ When minting via the JS SDK, simply provide the mint address of the NFT to burn 
 ```tsx
 const { nft } = await metaplex.candyMachines().mint({
   // ...
-  settings: {
+  guards: {
     nftBurn: {
       mint: nftToBurn.address,
     },

--- a/docs/01-programs/02-candy-machine/09-available-guards/10-nft-gate.md
+++ b/docs/01-programs/02-candy-machine/09-available-guards/10-nft-gate.md
@@ -59,7 +59,7 @@ When minting via the JS SDK, simply provide the mint address of the NFT to use a
 ```tsx
 const { nft } = await metaplex.candyMachines().mint({
   // ...
-  settings: {
+  guards: {
     nftGate: {
       mint: nftFromRequiredCollection.address,
     },

--- a/docs/01-programs/02-candy-machine/09-available-guards/11-nft-payment.md
+++ b/docs/01-programs/02-candy-machine/09-available-guards/11-nft-payment.md
@@ -63,7 +63,7 @@ When minting via the JS SDK, simply provide the mint address of the NFT to pay w
 ```tsx
 const { nft } = await metaplex.candyMachines().mint({
   // ...
-  settings: {
+  guards: {
     nftPayment: {
       mint: nftToPayWith.address,
     },

--- a/docs/01-programs/02-candy-machine/09-available-guards/15-third-party-signer.md
+++ b/docs/01-programs/02-candy-machine/09-available-guards/15-third-party-signer.md
@@ -60,7 +60,7 @@ When minting via the JS SDK, simply provide the third-party signer via the `sign
 ```tsx
 const { nft } = await metaplex.candyMachines().mint({
   // ...
-  settings: {
+  guards: {
     thirdPartySigner: {
       signer: someWallet,
     },


### PR DESCRIPTION
The docs are incorrect currently. On some pages it is shown that the guard settings should be set like this when calling the mint function:
```js
const { nft } = await metaplex.candyMachines().mint({
  candyMachine,
  collectionUpdateAuthority,
  group: "nft",
  settings: {
    thirdPartySigner: { signer: thirdPartySigner },
    nftPayment: { mint: nftFromRequiredCollection.address },
  },
});
```
the object is called guards though, not settings. Like this:
```js
const { nft } = await metaplex.candyMachines().mint({
  candyMachine,
  collectionUpdateAuthority,
  group: "nft",
  guards: {
    thirdPartySigner: { signer: thirdPartySigner },
    nftPayment: { mint: nftFromRequiredCollection.address },
  },
});
```
