### PR TITLE
Update 00-my-first-candy-machine-part1.md

### DIFF
--- a/docs/01-programs/02-candy-machine/10-how-to-guides/00-my-first-candy-machine-part1.md
+++ b/docs/01-programs/02-candy-machine/10-how-to-guides/00-my-first-candy-machine-part1.md
@@ -50,7 +50,7 @@ sugar
 <AccordionCode title="Output">
 
 ```
-sugar-cli 1.1.0-alpha+CMv3
+sugar-cli 2.0.0-beta.2
 Command line tool for creating and managing Metaplex Candy Machines.
 
 USAGE:
@@ -62,10 +62,12 @@ OPTIONS:
     -V, --version                  Print version information
 
 SUBCOMMANDS:
+    airdrop          Airdrop NFTs from candy machine
     bundlr           Interact with the bundlr network
     collection       Manage the collection on the candy machine
     create-config    Interactive process to create the config file
     deploy           Deploy cache items into candy machine config on-chain
+    freeze           Manage freeze guard actions
     guard            Manage guards on the candy machine
     hash             Generate hash of cache file for hidden settings
     help             Print this message or the help of the given subcommand(s)


### PR DESCRIPTION
Update the `sugar` output from version `2.0.0-beta.2`.

While trying this [guide](https://docs.metaplex.com/programs/candy-machine/how-to-guides/my-first-candy-machine-part1), I ended up installing Sugar 1 which caused me to fail the guide outcome, I'm proposing to update the `sugar` output to be specific about the version 2 requirement. I'm also aware that a peer got into this issue + another user mentioned it at Discord.