### PR TITLE
Update idl-docs.js

### DIFF
--- a/src/token-metadata/idl-docs.js
+++ b/src/token-metadata/idl-docs.js
@@ -170,7 +170,7 @@ export default {
       },
     },
     CollectionDetails: {
-      size: 8,
+      size: 10,
       description:
         "This optional enum allows us to differentiate Collection NFTs from Regular NFTs whilst adding additional context " +
         "such as the amount of NFTs that are linked to the Collection NFT. " +

--- a/src/token-metadata/idl-docs.js
+++ b/src/token-metadata/idl-docs.js
@@ -183,7 +183,7 @@ export default {
       },
     },
     ProgrammableConfig: {
-      size: 33,
+      size: 35,
       description:
         "This optional enum stores any data relevant to Programmable NFTs. " +
         "The different variants of the enum are used as versions so we can " +


### PR DESCRIPTION
Collection details takes 10 bytes, not 8:
1 for option identified, 1 for enum index, 8 for u64 field of only available enum variant.

Programmable config takes 35, not 33:
1 option identified + 1 enum index + 33 max enum value len (V1 value is Option<Pubkey> which is 1 option + 32 pubkey)