### PR TITLE
Sugar v2.1.1 released

### DIFF
--- a/docs/01-programs/02-candy-machine/11-how-to-guides/00-my-first-candy-machine-part1.md
+++ b/docs/01-programs/02-candy-machine/11-how-to-guides/00-my-first-candy-machine-part1.md
@@ -50,7 +50,7 @@ sugar
 <AccordionCode title="Output">
 
 ```
-sugar-cli 2.0.0
+sugar-cli 2.1.1
 Command line tool for creating and managing Metaplex Candy Machines.
 
 USAGE:
@@ -62,25 +62,24 @@ OPTIONS:
     -V, --version                  Print version information
 
 SUBCOMMANDS:
-    airdrop          Airdrop NFTs from candy machine
-    bundlr           Interact with the bundlr network
-    collection       Manage the collection on the candy machine
-    create-config    Interactive process to create the config file
-    deploy           Deploy cache items into candy machine config on-chain
-    freeze           Manage freeze guard actions
-    guard            Manage guards on the candy machine
-    hash             Generate hash of cache file for hidden settings
-    help             Print this message or the help of the given subcommand(s)
-    launch           Create a candy machine deployment from assets
-    mint             Mint one NFT from candy machine
-    reveal           Reveal the NFTs from a hidden settings candy machine
-    show             Show the on-chain config of an existing candy machine
-    sign             Sign one or all NFTs from candy machine
-    update           Update the candy machine config on-chain
-    upload           Upload assets to storage and creates the cache config
-    validate         Validate JSON metadata files
-    verify           Verify uploaded data
-    withdraw         Withdraw funds a from candy machine account closing it
+    airdrop       Airdrop NFTs from candy machine
+    bundlr        Interact with the bundlr network
+    collection    Manage the collection on the candy machine
+    config        Manage candy machine configuration
+    deploy        Deploy cache items into candy machine config on-chain
+    freeze        Manage freeze guard actions
+    guard         Manage guards on the candy machine
+    hash          Generate hash of cache file for hidden settings
+    help          Print this message or the help of the given subcommand(s)
+    launch        Create a candy machine deployment from assets
+    mint          Mint one NFT from candy machine
+    reveal        Reveal the NFTs from a hidden settings candy machine
+    show          Show the on-chain config of an existing candy machine
+    sign          Sign one or all NFTs from candy machine
+    upload        Upload assets to storage and creates the cache config
+    validate      Validate JSON metadata files
+    verify        Verify uploaded data
+    withdraw      Withdraw funds a from candy machine account closing it
 ```
 
 </AccordionCode>
@@ -108,12 +107,12 @@ We will run all our Sugar commands from within the project directory and Sugar w
 
 ## Create a Config File
 
-The config file tells Sugar how to configure your candy machine with values such as the number of assets, what creators to use, what settings to apply, etc. To create a config file we are going to use the Sugar `create-config` interactive command.
+The config file tells Sugar how to configure your candy machine with values such as the number of assets, what creators to use, what settings to apply, etc. To create a config file we are going to use the Sugar `config create` interactive command.
 
 Run the following command in your terminal from within your project directory:
 
 ```bash
-sugar create-config
+sugar config create
 ```
 
 We will now get a series of questions we need to answer to set up our config file.
@@ -683,6 +682,7 @@ sugar withdraw
 
 Do you want to learn more about sugar and the Candy Machine? These documents might be interesting for you:
 
+- [How to create a Candy Machine v3 - Part 2 (Umi)](./my-first-candy-machine-part2-umi)
 - [How to create a Candy Machine v3 - Part 2 (JS SDK)](./my-first-candy-machine-part2)
 - [Guards](/programs/candy-machine/candy-guards)
 - [Guard Groups](/programs/candy-machine/guard-groups)

--- a/docs/01-programs/02-candy-machine/11-how-to-guides/01-my-first-candy-machine-part2-umi.md
+++ b/docs/01-programs/02-candy-machine/11-how-to-guides/01-my-first-candy-machine-part2-umi.md
@@ -1,0 +1,9 @@
+---
+description: "Shows how to create a basic mint page with Metaplex Umi"
+---
+
+import { Accordion, AccordionItem } from '/src/accordion.jsx';
+import { AccordionCode } from '/src/accordion-code.jsx';
+
+# How to create a Candy Machine v3 - Part 2 (Umi)
+A guide on how to create a simple mint page will follow here.

--- a/docs/01-programs/02-candy-machine/11-how-to-guides/01-my-first-candy-machine-part2.md
+++ b/docs/01-programs/02-candy-machine/11-how-to-guides/01-my-first-candy-machine-part2.md
@@ -12,6 +12,8 @@ The code that you will see in this Guide and the [mint-example-ui code on Github
 
 :::caution
 This Guide is for Candy Machine v3 Account version v1. If you want to use the JS SDK the highest sugar version you can use is [v2.0](https://github.com/metaplex-foundation/sugar/releases/tag/v2.0.0). With later versions you have to the [Umi Guide](./my-first-candy-machine-part2-umi).
+
+This guide does NOT support programmable NFT (pNFT, royalty enforcement)
 :::
 
 ## Prerequisite Knowledge

--- a/docs/01-programs/02-candy-machine/11-how-to-guides/01-my-first-candy-machine-part2.md
+++ b/docs/01-programs/02-candy-machine/11-how-to-guides/01-my-first-candy-machine-part2.md
@@ -10,6 +10,10 @@ In this Guide, we will show you how to leverage the [Metaplex JS SDK](https://gi
 
 The code that you will see in this Guide and the [mint-example-ui code on Github](https://github.com/metaplex-foundation/js-examples/tree/main/mint-ui-example) is written to be as easily understandable as possible, and neither perfectly compliant with Next JS rules nor being as smart as possible, but instead to make it as easily readable as possible.
 
+:::caution
+This Guide is for Candy Machine v3 Account version v1. If you want to use the JS SDK the highest sugar version you can use is [v2.0](https://github.com/metaplex-foundation/sugar/releases/tag/v2.0.0). With later versions you have to the [Umi Guide](./my-first-candy-machine-part2-umi).
+:::
+
 ## Prerequisite Knowledge
 
 - You should have a basic understanding of how to find and use a terminal on your OS, including navigating directories, and running commands: an example of a terminal for macOS is [iTerm2](https://iterm2.com/).

--- a/docs/03-developer-tools/00-sugar/01-overview/01-installation.md
+++ b/docs/03-developer-tools/00-sugar/01-overview/01-installation.md
@@ -24,7 +24,7 @@ Run this install script in your terminal:
 bash <(curl -sSf https://sugar.metaplex.com/install.sh)
 ```
 
-This will install the binary to your machine and add it to your PATH.
+This will install the binary to your machine and add it to your PATH. You will be asked which version you want to use. V1.x is for Candy Machine v2, V2.x is for Candy Machine v3. We recommend to use the latest version.
 
 </TabItem>
 

--- a/docs/03-developer-tools/00-sugar/03-guides/04-sugar-for-cmv3.md
+++ b/docs/03-developer-tools/00-sugar/03-guides/04-sugar-for-cmv3.md
@@ -1,9 +1,7 @@
 # Sugar for Candy Machine V3
 
-:::caution
-Sugar support for Candy Machine V3 is experimental.
-
-📦 The alpha release binaries can be downloaded from [**Sugar's repository**](https://github.com/metaplex-foundation/sugar/releases). Choose the latest release with `cmv3` in it's name.
+:::info
+For Candy Machine V3 you have to use a Sugar version > v2.0 
 :::
 
 The Candy Machine V3 is the latest iteration of the Metaplex Protocol's Candy Machine minting and distribution program. While the deploy of a Candy Machine V3 works largely similar to the previous V2 version, Sugar offers a set of new command to configure and manage a Candy Guard.


### PR DESCRIPTION
following issues have been fixed:

- `create-config` instead of `config create`
- Mention the alpha version for CM v3 even though there is a stable version released for months
- do not warn in the JS SDK mintpage guide that it will not work for pNFT / royalty enforcement / the latest sugar version