### PR TITLE
fix info about who can invoke the `Utilize` ix

### DIFF
--- a/docs/01-programs/01-token-metadata/03-instructions.md
+++ b/docs/01-programs/01-token-metadata/03-instructions.md
@@ -243,7 +243,7 @@ It does this by deleting the provided `Collection Authority Record` PDA.
 
 This instruction reduces the number of uses of a Metadata account.
 
-This can either be done by the `Update Authority` of the Metadata account or by an approved `Use Authority`.
+This can either be done by the owner of the NFT or by an approved `Use Authority`.
 
 </ProgramInstruction>
 


### PR DESCRIPTION
`Utilize` can be signed by the owner, not the update authority, as can be seen in the [code](https://github.com/metaplex-foundation/metaplex-program-library/blob/a3251589bf4b79378b2d75d3587702a0385c3529/token-metadata/program/src/processor/uses/utilize.rs#L109C15-L109C46)